### PR TITLE
Update DevSecOps-lab.md

### DIFF
--- a/guide/DevSecOps-lab.md
+++ b/guide/DevSecOps-lab.md
@@ -635,6 +635,13 @@ resource "aws_s3_bucket" "dev_s3" {
   }
 }
 
+resource "aws_s3_bucket_ownership_controls" "dev_s3" {
+  bucket = aws_s3_bucket.dev_s3.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 ```
 
 Once complete, click `Commit changes...` at the top right, then select `Create a new branch and start a pull request` and click `Propose changes`.


### PR DESCRIPTION
Add ACL configuration to S3 Bucket so runs will work from terraform cloud

## Description

Changed the s3.tf file to add some configuration to the bucket

## Motivation and Context

Buckets now default to disabling ACLs on AWS so this is needed to overide that default

## How Has This Been Tested?

I tested in my fork

## Screenshots (if appropriate)



## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
